### PR TITLE
Themes and Industries filter changes.

### DIFF
--- a/conf/cmi/views.view.taxonomy_terms_terms_.yml
+++ b/conf/cmi/views.view.taxonomy_terms_terms_.yml
@@ -904,7 +904,7 @@ display:
           value:
             min: ''
             max: ''
-            value: '27'
+            value: '73'
           group: 1
           exposed: false
           expose:
@@ -1013,7 +1013,7 @@ display:
       tags: {  }
   block_4:
     id: block_4
-    display_title: 'Industries and businesses'
+    display_title: 'Divisions'
     display_plugin: block
     position: 2
     display_options:
@@ -1348,12 +1348,12 @@ display:
           admin_label: ''
           plugin_id: text_custom
           empty: false
-          content: "<h3>Toimialat ja liikelaitokset</h3>\r\n<div role=\"status\" class=\"visually-hidden\" aria-hidden=\"true\">\r\n<p>[view:total-rows] tulosta</p>\r\n</div>"
+          content: "<h3>Toimialat</h3>\r\n<div role=\"status\" class=\"visually-hidden\" aria-hidden=\"true\">\r\n<p>[view:total-rows] tulosta</p>\r\n</div>"
           tokenize: false
       display_extenders:
         simple_sitemap_display_extender: {  }
         metatag_display_extender: {  }
-      block_description: 'Industries and businesses'
+      block_description: 'Divisions'
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
Value of Taxonomy term's id in Themes filter is changed from 27 to 73,
Industries and businesses' replaced with 'Divisions' in the Industry
Merge pull request #14 from City-of-Helsinki/PLATTA-4296
Julkaisut application is missing taas Teemat-menu/PLATTA-4380